### PR TITLE
fix: normalize input sha to a shortcode for ancestor checks

### DIFF
--- a/src/version-base.ts
+++ b/src/version-base.ts
@@ -77,7 +77,7 @@ export abstract class BaseVersioner {
           this.DEFAULT_BRANCH
         );
         // If we are literally on the merge point consider it not an ancestor
-        if (releaseBranchPoint === sha) {
+        if (releaseBranchPoint === sha.substring(0, 7)) {
           isAncestor = false;
         } else {
           isAncestor = await this.isAncestor(releaseBranchPoint, sha);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -35,6 +35,9 @@ describe.each([
     ['the first minor release branch (release-1.0.x)', 'b2bcb99', '1.0.2'],
     ['the default branch before any release branches', '829eb2f', '0.0.1'],
     ['the branch point for a release branch', '4507940', '4.1.6'],
+    ['the branch point for a release branch with a full SHA', '45079400b565b91a146a1699d50da9d2d4170a33', '4.1.6'],
+    ['the commit after the branch point for a release branch on a release branch', 'c95b710', '4.1.7'],
+    ['the commit after the branch point for a release branch on the mainline branch', '7842465', '4.2.1'],
     ['commit branched from trunk', '499537a', '4.2.65535'],
     ['commit branched from release branch', '57deab3', '4.0.65535'],
     [


### PR DESCRIPTION
This caused an issue with the `4.28.133` release where because we used a full SHA it failed this ancestor check and after the branch was made it magically became `4.29.0` which is a release that should _never_ exist.