### PR TITLE
fix: throw better error if no release branches detected

### DIFF
--- a/src/version-base.ts
+++ b/src/version-base.ts
@@ -255,6 +255,10 @@ export abstract class BaseVersioner {
       )
       .filter((branch) => branch !== null) as RegExpExecArray[];
 
+    if (releaseBranchNames.length === 0) {
+      throw new Error('No release branches detected.');
+    }
+
     return releaseBranchNames
       .map(([branchName, major, minor]) => {
         return {


### PR DESCRIPTION
Catch this as early as possible to avoid cryptic array index errors later on.