### PR TITLE
fix(github): use paginated API and propagate default branch

### DIFF
--- a/src/version-base.ts
+++ b/src/version-base.ts
@@ -39,7 +39,7 @@ export abstract class BaseVersioner {
    */
   protected abstract isAncestor(from: string, to: string): Promise<boolean>;
 
-  protected DEFAULT_BRANCH = 'main';
+  protected defaultBranch = 'main';
   protected releaseBranchMatcher =
     /^(?:origin\/)?release-([0-9]+)\.([0-9]+)\.x$/;
 
@@ -71,13 +71,13 @@ export abstract class BaseVersioner {
 
     const releaseBranches = await this.getReleaseBranches();
 
-    if (currentBranch === this.DEFAULT_BRANCH) {
+    if (currentBranch === this.defaultBranch) {
       let lastReleaseBranchWithAncestor;
       for (const releaseBranch of releaseBranches) {
         let isAncestor = false;
         const releaseBranchPoint = await this.getMergeBase(
           releaseBranch.branch,
-          this.DEFAULT_BRANCH
+          this.defaultBranch
         );
         // If we are literally on the merge point consider it not an ancestor
         if (releaseBranchPoint === sha.substring(0, 7)) {
@@ -95,12 +95,12 @@ export abstract class BaseVersioner {
 
         if (!this.silent)
           console.error(
-            `On ${this.DEFAULT_BRANCH} so the version is considered to be the next unreleased minor`,
+            `On ${this.defaultBranch} so the version is considered to be the next unreleased minor`,
             `${targetMajor}.${targetMinor}`
           );
 
         const firstCommitInLatestRelease = await this.getMergeBase(
-          this.DEFAULT_BRANCH,
+          this.defaultBranch,
           lastReleaseBranchWithAncestor.branch
         );
         const commitsSinceLatestReleaseBranch = await this.getDistance(
@@ -109,7 +109,7 @@ export abstract class BaseVersioner {
         );
         if (!this.silent)
           console.error(
-            `${commitsSinceLatestReleaseBranch} commits on ${this.DEFAULT_BRANCH} since the last minor was branched`
+            `${commitsSinceLatestReleaseBranch} commits on ${this.defaultBranch} since the last minor was branched`
           );
 
         return `${targetMajor}.${targetMinor}.${commitsSinceLatestReleaseBranch}`;
@@ -158,11 +158,11 @@ export abstract class BaseVersioner {
           );
 
         const firstCommitInPreviousRelease = await this.getMergeBase(
-          this.DEFAULT_BRANCH,
+          this.defaultBranch,
           previousReleaseBranch.branch
         );
         const firstCommitInCurrentRelease = await this.getMergeBase(
-          this.DEFAULT_BRANCH,
+          this.defaultBranch,
           releaseBranch.branch
         );
         const commitsOnDefaultBranchBetweenReleases = await this.getDistance(
@@ -174,7 +174,7 @@ export abstract class BaseVersioner {
             'Calculated that there were',
             commitsOnDefaultBranchBetweenReleases,
             'commits on the',
-            this.DEFAULT_BRANCH,
+            this.defaultBranch,
             'branch between the previous release and this release'
           );
 
@@ -296,7 +296,7 @@ export abstract class BaseVersioner {
     sha: string
   ) {
     let nearestReleaseBranch = {
-      branch: this.DEFAULT_BRANCH,
+      branch: this.defaultBranch,
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       version: semver
         .parse(releaseBranches[releaseBranches.length - 1].version.format())!
@@ -304,13 +304,10 @@ export abstract class BaseVersioner {
     };
     for (const releaseBranch of releaseBranches) {
       const branchPointOfReleaseBranch = await this.getMergeBase(
-        this.DEFAULT_BRANCH,
+        this.defaultBranch,
         releaseBranch.branch
       );
-      const branchPointOfSHA = await this.getMergeBase(
-        this.DEFAULT_BRANCH,
-        sha
-      );
+      const branchPointOfSHA = await this.getMergeBase(this.defaultBranch, sha);
       if (branchPointOfReleaseBranch === branchPointOfSHA) {
         nearestReleaseBranch = releaseBranch;
         break;

--- a/src/version-github.ts
+++ b/src/version-github.ts
@@ -18,7 +18,7 @@ export default class GitHubVersioner extends BaseVersioner {
     super();
     this.owner = opts.owner;
     this.repo = opts.repo;
-    this.DEFAULT_BRANCH = opts.defaultBranch || 'main';
+    this.defaultBranch = opts.defaultBranch || 'main';
     this.gitHub = new Octokit({ auth: opts.authOptions });
   }
 
@@ -26,7 +26,7 @@ export default class GitHubVersioner extends BaseVersioner {
     const response = await this.gitHub.rest.repos.getCommit({
       owner: this.owner,
       repo: this.repo,
-      ref: this.DEFAULT_BRANCH,
+      ref: this.defaultBranch,
     });
 
     return response.data.sha;
@@ -59,7 +59,7 @@ export default class GitHubVersioner extends BaseVersioner {
   protected async getBranchForCommit(SHA: string) {
     const branches = [
       ...(await this.getReleaseBranches()).map((b) => b.branch),
-      this.DEFAULT_BRANCH,
+      this.defaultBranch,
     ];
 
     const possibleBranches: string[] = [];
@@ -81,8 +81,8 @@ export default class GitHubVersioner extends BaseVersioner {
       );
 
     possibleBranches.sort((a, b) => {
-      if (a === this.DEFAULT_BRANCH) return -1;
-      if (b === this.DEFAULT_BRANCH) return 1;
+      if (a === this.defaultBranch) return -1;
+      if (b === this.defaultBranch) return 1;
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       const [, aMinor] = this.releaseBranchMatcher.exec(a)!;
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
@@ -127,7 +127,7 @@ export default class GitHubVersioner extends BaseVersioner {
     const lastCommit: any = await this.gitHub.graphql(
       `{
         repository(name: "${this.repo}", owner: "${this.owner}") {
-          ref(qualifiedName: "${this.DEFAULT_BRANCH}") {
+          ref(qualifiedName: "${this.defaultBranch}") {
             target {
               ... on Commit {
                 history(first: 1) {
@@ -153,7 +153,7 @@ export default class GitHubVersioner extends BaseVersioner {
     const firstCommit: any = await this.gitHub.graphql(
       `{
         repository(name: "${this.repo}", owner: "${this.owner}") {
-          ref(qualifiedName: "${this.DEFAULT_BRANCH}") {
+          ref(qualifiedName: "${this.defaultBranch}") {
             target {
               ... on Commit {
                 history(first: 1, after: "${magicIncantation}") {

--- a/src/version-local.ts
+++ b/src/version-local.ts
@@ -17,7 +17,7 @@ export default class LocalVersioner extends BaseVersioner {
       ? path.resolve(opts.pathToRepo)
       : process.cwd();
 
-    this.DEFAULT_BRANCH = opts.defaultBranch || 'main';
+    this.defaultBranch = opts.defaultBranch || 'main';
 
     if (!fs.existsSync(this.pathToRepo)) {
       throw new Error(
@@ -52,7 +52,7 @@ export default class LocalVersioner extends BaseVersioner {
 
     const possibleReleaseBranches = possibleBranches.filter(
       (branch) =>
-        this.releaseBranchMatcher.test(branch) || branch === this.DEFAULT_BRANCH
+        this.releaseBranchMatcher.test(branch) || branch === this.defaultBranch
     );
 
     // If we're searching for the current HEAD, prioritize the current
@@ -75,8 +75,8 @@ export default class LocalVersioner extends BaseVersioner {
         `Found release branch(es) [${possibleReleaseBranches.join(', ')}].`
       );
     possibleReleaseBranches.sort((a, b) => {
-      if (a === this.DEFAULT_BRANCH) return -1;
-      if (b === this.DEFAULT_BRANCH) return 1;
+      if (a === this.defaultBranch) return -1;
+      if (b === this.defaultBranch) return 1;
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       const [, aMinor] = this.releaseBranchMatcher.exec(a)!;
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
@@ -98,12 +98,12 @@ export default class LocalVersioner extends BaseVersioner {
     // For example, this matters if we're on a detached HEAD
     // on the main branch.
     const fixedFrom =
-      (from === this.DEFAULT_BRANCH || this.releaseBranchMatcher.test(from)) &&
+      (from === this.defaultBranch || this.releaseBranchMatcher.test(from)) &&
       !from.startsWith('origin/')
         ? `origin/${from}`
         : from;
     const fixedTo =
-      (to === this.DEFAULT_BRANCH || this.releaseBranchMatcher.test(to)) &&
+      (to === this.defaultBranch || this.releaseBranchMatcher.test(to)) &&
       !to.startsWith('origin/')
         ? `origin/${to}`
         : to;


### PR DESCRIPTION
Fix issues specific to the GitHub versioner, which is undergoing its first test.

* `getAllBranches()` did not work as intended in its previous state for repos with a lot of branches because the GitHub API paginates branches.
* The `defaultBranch` option was forgotten in the GitHub versioner.