### PR TITLE
refactor(github): loop backwards when iterating

### DIFF
--- a/src/version-base.ts
+++ b/src/version-base.ts
@@ -280,7 +280,8 @@ export abstract class BaseVersioner {
         };
       })
       .sort((a, b) => {
-        return b.version.compare(a.version);
+        // Sorted in descending order.
+        return a.version.compare(b.version) * -1;
       });
   }
 

--- a/src/version-base.ts
+++ b/src/version-base.ts
@@ -73,7 +73,7 @@ export abstract class BaseVersioner {
 
     if (currentBranch === this.defaultBranch) {
       let lastReleaseBranchWithAncestor;
-      for (const releaseBranch of releaseBranches.reverse()) {
+      for (const releaseBranch of releaseBranches) {
         let isAncestor = false;
         const releaseBranchPoint = await this.getMergeBase(
           releaseBranch.branch,
@@ -143,7 +143,7 @@ export abstract class BaseVersioner {
         );
 
       // If we're on the first-ever release branch, we count versions from the dawn of time
-      if (releaseBranchIndex === 0) {
+      if (releaseBranchIndex === releaseBranches.length - 1) {
         const firstCommit = await this.getFirstCommit();
         const commitsSinceInitialCommit = await this.getDistance(
           firstCommit,
@@ -152,7 +152,7 @@ export abstract class BaseVersioner {
 
         return `${releaseBranch.version.major}.${releaseBranch.version.minor}.${commitsSinceInitialCommit}`;
       } else {
-        const previousReleaseBranch = releaseBranches[releaseBranchIndex - 1];
+        const previousReleaseBranch = releaseBranches[releaseBranchIndex + 1];
         if (!this.silent)
           console.error(
             'Determined previous release branch to be:',
@@ -280,7 +280,7 @@ export abstract class BaseVersioner {
         };
       })
       .sort((a, b) => {
-        return a.version.compare(b.version);
+        return b.version.compare(a.version);
       });
   }
 
@@ -300,9 +300,7 @@ export abstract class BaseVersioner {
     let nearestReleaseBranch = {
       branch: this.defaultBranch,
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-      version: semver
-        .parse(releaseBranches[releaseBranches.length - 1].version.format())!
-        .inc('minor'),
+      version: semver.parse(releaseBranches[0].version.format())!.inc('minor'),
     };
     for (const releaseBranch of releaseBranches) {
       const branchPointOfReleaseBranch = await this.getMergeBase(

--- a/src/version-base.ts
+++ b/src/version-base.ts
@@ -73,7 +73,7 @@ export abstract class BaseVersioner {
 
     if (currentBranch === this.defaultBranch) {
       let lastReleaseBranchWithAncestor;
-      for (const releaseBranch of releaseBranches) {
+      for (const releaseBranch of releaseBranches.reverse()) {
         let isAncestor = false;
         const releaseBranchPoint = await this.getMergeBase(
           releaseBranch.branch,
@@ -85,8 +85,10 @@ export abstract class BaseVersioner {
         } else {
           isAncestor = await this.isAncestor(releaseBranchPoint, sha);
         }
-        if (!isAncestor) break;
-        lastReleaseBranchWithAncestor = releaseBranch;
+        if (isAncestor) {
+          lastReleaseBranchWithAncestor = releaseBranch;
+          break;
+        }
       }
 
       if (lastReleaseBranchWithAncestor) {

--- a/src/version-github.ts
+++ b/src/version-github.ts
@@ -79,7 +79,9 @@ export default class GitHubVersioner extends BaseVersioner {
       }
     }
 
-    throw new Error('getBranchForCommit: No release branch found');
+    throw new Error(
+      'Not on release branch: GitHub Versioner does not support lookup for non-release branches'
+    );
   }
 
   protected async getMergeBase(from: string, to: string) {

--- a/src/version-github.ts
+++ b/src/version-github.ts
@@ -62,9 +62,9 @@ export default class GitHubVersioner extends BaseVersioner {
 
   protected async getBranchForCommit(SHA: string) {
     const branches = [
-      ...(await this.getReleaseBranches()).map((b) => b.branch),
       this.defaultBranch,
-    ].reverse();
+      ...(await this.getReleaseBranches()).map((b) => b.branch),
+    ];
 
     for (const branch of branches) {
       const res = await this.gitHub.rest.repos.compareCommitsWithBasehead({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -31,10 +31,10 @@ describe.each([
   describe.skipIf(
     !process.env.GITHUB_TOKEN && versioner instanceof GitHubVersioner
   )('it', () => {
-    it('generates the correct version from the default branch HEAD', async () => {
-      const latestVersion = await versioner.getVersionForHead();
-      expect(latestVersion).toBe('4.2.4');
-    });
+    // it('generates the correct version from the default branch HEAD', async () => {
+    //   const latestVersion = await versioner.getVersionForHead();
+    //   expect(latestVersion).toBe('4.2.4');
+    // });
 
     it.each([
       ['the tip of a release branch (release-4.1.x)', 'ece1c3f', '4.1.8'],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -31,10 +31,10 @@ describe.each([
   describe.skipIf(
     !process.env.GITHUB_TOKEN && versioner instanceof GitHubVersioner
   )('it', () => {
-    // it('generates the correct version from the default branch HEAD', async () => {
-    //   const latestVersion = await versioner.getVersionForHead();
-    //   expect(latestVersion).toBe('4.2.4');
-    // });
+    it('generates the correct version from the default branch HEAD', async () => {
+      const latestVersion = await versioner.getVersionForHead();
+      expect(latestVersion).toBe('4.2.4');
+    });
 
     it.each([
       ['the tip of a release branch (release-4.1.x)', 'ece1c3f', '4.1.8'],
@@ -58,8 +58,16 @@ describe.each([
         '7842465',
         '4.2.1',
       ],
-      ['commit branched from trunk', '499537a', '4.2.65535'],
-      ['commit branched from release branch', '57deab3', '4.0.65535'],
+      [
+        'commit branched from trunk',
+        '499537a',
+        versioner instanceof GitHubVersioner ? Error : '4.2.65535',
+      ],
+      [
+        'commit branched from release branch',
+        '57deab3',
+        versioner instanceof GitHubVersioner ? Error : '4.0.65535',
+      ],
       [
         'a full length commit SHA',
         'dc328b57827d8619719f1783a21b05968652eaf3',
@@ -68,9 +76,15 @@ describe.each([
     ])(
       'generates the correct version from %s',
       async (_, sha, expectedVersion) => {
-        const version = await versioner.getVersionForCommit(sha);
-        const parsed = semver.parse(version);
-        expect(parsed?.version).toBe(expectedVersion);
+        if (expectedVersion instanceof Error) {
+          await expect(versioner.getVersionForCommit(sha)).rejects.toThrow(
+            Error
+          );
+        } else {
+          const version = await versioner.getVersionForCommit(sha);
+          const parsed = semver.parse(version);
+          expect(parsed?.version).toBe(expectedVersion);
+        }
       }
     );
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -61,12 +61,16 @@ describe.each([
       [
         'commit branched from trunk',
         '499537a',
-        versioner instanceof GitHubVersioner ? Error : '4.2.65535',
+        versioner instanceof GitHubVersioner
+          ? new Error('Not on release branch')
+          : '4.2.65535',
       ],
       [
         'commit branched from release branch',
         '57deab3',
-        versioner instanceof GitHubVersioner ? Error : '4.0.65535',
+        versioner instanceof GitHubVersioner
+          ? new Error('Not on release branch')
+          : '4.0.65535',
       ],
       [
         'a full length commit SHA',


### PR DESCRIPTION
This PR improves performance of the GitHub method by iterating through release branches backwards.

Although the search is O(n), each API request taking 500-1000ms makes requests for recent branches slow. Since we're way more likely to look for recent releases, the easiest way of solving the problem is to reverse the direction of the search.

This PR also limits functionality for generating build numbers for dev branches because they're functionally useless for lookup purposes.