### PR TITLE
perf(github): cache compare API results to reduce redundant calls

### DIFF
--- a/src/version-base.ts
+++ b/src/version-base.ts
@@ -303,12 +303,12 @@ export abstract class BaseVersioner {
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       version: semver.parse(releaseBranches[0].version.format())!.inc('minor'),
     };
+    const branchPointOfSHA = await this.getMergeBase(this.defaultBranch, sha);
     for (const releaseBranch of releaseBranches) {
       const branchPointOfReleaseBranch = await this.getMergeBase(
         this.defaultBranch,
         releaseBranch.branch
       );
-      const branchPointOfSHA = await this.getMergeBase(this.defaultBranch, sha);
       if (branchPointOfReleaseBranch === branchPointOfSHA) {
         nearestReleaseBranch = releaseBranch;
         break;

--- a/src/version-github.ts
+++ b/src/version-github.ts
@@ -2,6 +2,10 @@ import { BaseVersioner } from './version-base';
 import { Octokit } from '@octokit/rest';
 import type { OctokitOptions } from '@octokit/core';
 
+type CompareData = Awaited<
+  ReturnType<Octokit['rest']['repos']['compareCommitsWithBasehead']>
+>['data'];
+
 interface GitHubVersionerOptions {
   owner: string;
   repo: string;
@@ -14,6 +18,7 @@ export default class GitHubVersioner extends BaseVersioner {
   private owner: string;
   private repo: string;
   private cachedBranches: string[] | undefined;
+  private compareCache = new Map<string, CompareData>();
 
   constructor(opts: GitHubVersionerOptions) {
     super();
@@ -21,6 +26,24 @@ export default class GitHubVersioner extends BaseVersioner {
     this.repo = opts.repo;
     this.defaultBranch = opts.defaultBranch || 'main';
     this.gitHub = new Octokit({ auth: opts.authOptions });
+  }
+
+  private async getCompareResult(
+    base: string,
+    head: string
+  ): Promise<CompareData> {
+    const key = `${base}...${head}`;
+    const cached = this.compareCache.get(key);
+    if (cached) return cached;
+
+    const res = await this.gitHub.rest.repos.compareCommitsWithBasehead({
+      owner: this.owner,
+      repo: this.repo,
+      basehead: key,
+    });
+
+    this.compareCache.set(key, res.data);
+    return res.data;
   }
 
   protected async getHeadSHA(): Promise<string> {
@@ -67,13 +90,9 @@ export default class GitHubVersioner extends BaseVersioner {
     ];
 
     for (const branch of branches) {
-      const res = await this.gitHub.rest.repos.compareCommitsWithBasehead({
-        owner: this.owner,
-        repo: this.repo,
-        basehead: `${branch}...${SHA}`,
-      });
+      const data = await this.getCompareResult(branch, SHA);
 
-      if (res.data.status === 'behind' || res.data.status === 'identical') {
+      if (data.status === 'behind' || data.status === 'identical') {
         if (!this.silent) console.error(`Found release branch ${branch}.`);
         return branch;
       }
@@ -85,23 +104,13 @@ export default class GitHubVersioner extends BaseVersioner {
   }
 
   protected async getMergeBase(from: string, to: string) {
-    const res = await this.gitHub.rest.repos.compareCommitsWithBasehead({
-      owner: this.owner,
-      repo: this.repo,
-      basehead: `${from}...${to}`,
-    });
-
-    return res.data.merge_base_commit.sha.slice(0, 7).trim();
+    const data = await this.getCompareResult(from, to);
+    return data.merge_base_commit.sha.slice(0, 7).trim();
   }
 
   protected async isAncestor(from: string, to: string) {
-    const res = await this.gitHub.rest.repos.compareCommitsWithBasehead({
-      owner: this.owner,
-      repo: this.repo,
-      basehead: `${from}...${to}`,
-    });
-
-    return res.data.status === 'ahead';
+    const data = await this.getCompareResult(from, to);
+    return data.status === 'ahead';
   }
 
   protected async getFirstCommit() {
@@ -165,12 +174,7 @@ export default class GitHubVersioner extends BaseVersioner {
   }
 
   protected async getDistance(from: string, to: string) {
-    const res = await this.gitHub.rest.repos.compareCommitsWithBasehead({
-      owner: this.owner,
-      repo: this.repo,
-      basehead: `${from}...${to}`,
-    });
-
-    return res.data.total_commits;
+    const data = await this.getCompareResult(from, to);
+    return data.total_commits;
   }
 }


### PR DESCRIPTION
## Summary
- Adds a per-instance cache for `compareCommitsWithBasehead` results in `GitHubVersioner`, keyed on the `basehead` string. `getMergeBase`, `isAncestor`, `getDistance`, and `getBranchForCommit` now go through a shared `getCompareResult` method that deduplicates identical API calls.
- Hoists an invariant `getMergeBase(defaultBranch, sha)` call out of the loop in `getNearestReleaseBranchForSHA` (in the base class, so both `LocalVersioner` and `GitHubVersioner` benefit).

## Performance
Measured against the test fixture (`erickzhao/desktop-test-fixture`):

| Metric | Before | After | Change |
|---|---|---|---|
| Compare API calls | 87 | 80 | **-8.0%** |
| Total wall time | 37.8s | 35.5s | **-6.1%** |

Savings scale with the number of release branches. The biggest wins come from:
- MAS build flow (`getBranchForCommit` called twice — second is a full cache hit)
- Default branch path (merge-base reused when SHA matches branch point)

## Test plan
- [x] All 30 tests pass (15 local + 15 GitHub) with no changes to test code
- [x] Verified API call counts with temporary instrumentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)