### PR TITLE
fix: prefer release branch for MAS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "@malept/cross-spawn-promise": "^2.0.0",
     "@octokit/rest": "^22.0.1",
     "commander": "^13.1.0",
-    "dotenv": "^16.0.1",
     "semver": "^7.7.4"
   },
   "devDependencies": {
     "@types/node": "^22.13.1",
     "@types/semver": "^7.7.1",
+    "dotenv": "^16.0.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.3.0",
     "oxfmt": "^0.39.0",

--- a/src/version-github.ts
+++ b/src/version-github.ts
@@ -61,10 +61,26 @@ export default class GitHubVersioner extends BaseVersioner {
   }
 
   protected async getBranchForCommit(SHA: string) {
-    const branches = [
-      this.defaultBranch,
-      ...(await this.getReleaseBranches()).map((b) => b.branch),
-    ];
+    const releaseBranches = (await this.getReleaseBranches()).map(
+      (b) => b.branch
+    );
+    const branches = [this.defaultBranch, ...releaseBranches];
+
+    // When a release branch is created directly off the default branch,
+    // the tip commit exists on both. Prefer the release branch by checking
+    // for identical (tip) matches on release branches first.
+    for (const branch of releaseBranches) {
+      const res = await this.gitHub.rest.repos.compareCommitsWithBasehead({
+        owner: this.owner,
+        repo: this.repo,
+        basehead: `${branch}...${SHA}`,
+      });
+
+      if (res.data.status === 'identical') {
+        if (!this.silent) console.error(`Found release branch ${branch}.`);
+        return branch;
+      }
+    }
 
     for (const branch of branches) {
       const res = await this.gitHub.rest.repos.compareCommitsWithBasehead({

--- a/src/version-local.ts
+++ b/src/version-local.ts
@@ -74,6 +74,29 @@ export default class LocalVersioner extends BaseVersioner {
       console.error(
         `Found release branch(es) [${possibleReleaseBranches.join(', ')}].`
       );
+
+    // When a release branch is created directly off the default branch,
+    // the tip commit exists on both branches. In that case, prefer the
+    // release branch — otherwise getMASBuildVersionForCommit returns 0.
+    // We detect this by checking if the commit is at the tip of a release branch.
+    const releaseBranchesOnly = possibleReleaseBranches.filter(
+      (b) => b !== this.defaultBranch
+    );
+    if (releaseBranchesOnly.length > 0) {
+      for (const branch of releaseBranchesOnly) {
+        const branchTip = (
+          await this.spawnGit(['rev-parse', `origin/${branch}`])
+        ).trim();
+        if (branchTip.slice(0, 7) === SHA.slice(0, 7)) {
+          if (!this.silent)
+            console.error(
+              `Commit is at the tip of release branch ${branch}, preferring it over ${this.defaultBranch}.`
+            );
+          return branch;
+        }
+      }
+    }
+
     possibleReleaseBranches.sort((a, b) => {
       if (a === this.defaultBranch) return -1;
       if (b === this.defaultBranch) return 1;

--- a/test/detached-head-release.test.ts
+++ b/test/detached-head-release.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import LocalVersioner from '../src/version-local';
+
+describe('Release branch created at same commit as default branch', () => {
+  let tmpDir: string;
+  let headSha: string;
+
+  beforeAll(() => {
+    console.error = vi.fn();
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dv-test-'));
+
+    const git = (cmd: string) =>
+      execSync(`git ${cmd}`, {
+        cwd: tmpDir,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+
+    git('init -b main');
+    git('config user.email "test@test.com"');
+    git('config user.name "Test"');
+
+    // Create initial history with a few commits
+    fs.writeFileSync(path.join(tmpDir, 'file.txt'), '1');
+    git('add .');
+    git('commit -m "Initial commit"');
+
+    fs.writeFileSync(path.join(tmpDir, 'file.txt'), '2');
+    git('add .');
+    git('commit -m "Second commit"');
+
+    // Create an older release branch so our new one isn't the "first-ever"
+    git('branch release-4.49.x');
+
+    fs.writeFileSync(path.join(tmpDir, 'file.txt'), '3');
+    git('add .');
+    git('commit -m "Third commit"');
+
+    // Create release-4.50.x at the current tip of main
+    git('branch release-4.50.x');
+
+    headSha = git('rev-parse HEAD');
+
+    // Simulate a remote by creating origin/ refs
+    git('remote add origin ' + tmpDir);
+    git('fetch origin');
+
+    // Simulate CI detached HEAD on the release branch commit
+    git('checkout --detach HEAD');
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('getMASBuildVersionForCommit returns a non-zero version', async () => {
+    const v = new LocalVersioner({
+      pathToRepo: tmpDir,
+      defaultBranch: 'main',
+    });
+
+    const masVersion = await v.getMASBuildVersionForCommit(headSha);
+    expect(masVersion).not.toBe('0');
+    // Should be 450XXXXXX format (major=4, minor=50, patch padded to 6)
+    expect(masVersion).toMatch(/^450\d{6}$/);
+  });
+
+  it('getVersionForCommit returns a release branch version', async () => {
+    const v = new LocalVersioner({
+      pathToRepo: tmpDir,
+      defaultBranch: 'main',
+    });
+
+    const version = await v.getVersionForCommit(headSha);
+    expect(version).toMatch(/^4\.50\.\d+$/);
+  });
+});


### PR DESCRIPTION
There's a long-standing bug in this library where cutting off a branch and immediately generating a build version will generate an invalid MAS version.

This PR fixes that by preferring a release branch for a given commit if that commit is both the `HEAD` reference of both a release branch _and_ `master`.

See `test/detached-head-release.test.ts` in this PR for a practical test case with the local versioner. Note that this doesn't regress any of the other test cases we have.